### PR TITLE
Tweak parameters to make it converge for example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,14 +68,14 @@ using JuMP
 import Penopt
 
 model = Model(Penopt.Optimizer)
-set_optimizer_attribute(model, "LS", 1)
-set_optimizer_attribute(model, "DIMACS", 0)
-set_optimizer_attribute(model, "P0", 0.1)
+set_optimizer_attribute(model, "PBM_EPS", 1e-5)
 set_optimizer_attribute(model, "PRECISION_2", 1e-6)
+
 @variable(model, x[1:3])
 @objective(model, Min, (x[1] - x[2])^2 / 2 + x[3])
 @constraint(model, -0.5 <= x[1] <= 2.0)
 @constraint(model, -3.0 <= x[2] <= 7.0)
+
 A0 = [-10  -0.5 -2
       -0.5  4.5  0
       -2    0    0]
@@ -89,12 +89,9 @@ K12 = [0    0    2
        0   -5.5  3
        2    3    0]
 @constraint(model, Symmetric(-A0 - x[1] * A1 - x[2] * A2 - x[1] * x[2] * K12 + x[3] * Matrix(I, 3, 3)) in PSDCone())
-optimize!(model)
 
+optimize!(model)
 println(solution_summary(model))
-@show MOI.get(model, Penopt.NumberOfOuterIterations())
-@show MOI.get(model, Penopt.NumberOfNewtonSteps())
-@show MOI.get(model, Penopt.NumberOfLinesearchSteps())
 ```
 
 ## Accessing Penopt-specific attributes via JuMP

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -2,8 +2,8 @@ import LinearAlgebra
 
 const IOPTIONS = String[
     "DEF",
-    "PBM MAX ITER",
-    "UM MAX ITER",
+    "PBM_MAX_ITER",
+    "UM_MAX_ITER",
     "OUTPUT",
     "DENSE",
     "LS",


### PR DESCRIPTION
The parameter `P0 = 0.1` was making it converge to `[-0.181129, -0.579887, 3.87969]` which objective value `4.038697821670394` while the default  `P0 = 1.1` makes it converge to `[1.114426361107073, 1.3222403877566897, -0.9261207007568707]` with objective value `-0.8829340310845435` which is much better.
Then, relaxing the tolerance `PBM_EPS` from its default `1e-6` to `1e-5` makes it stop before hitting any linesearch failure hence it now reports "No errors."